### PR TITLE
#12 CoU for AddressAdditionalInformation

### DIFF
--- a/input/fsh/at-core-ext-address-additionalInformation.fsh
+++ b/input/fsh/at-core-ext-address-additionalInformation.fsh
@@ -8,6 +8,7 @@ Extension:    AddressAdditionalInformation
 Id:           at-core-ext-address-additionalInformation
 Title:        "Address Additional Information" 
 Description:  "HL7® Austria FHIR® Core Extension for the additional information part of the Austrian address."
+Context:      Address.line, HL7ATCoreAddress.line
 
 * value[x] only string
 * value[x] 1..1


### PR DESCRIPTION
added the relevant context of use to the extension

Closes #12 